### PR TITLE
Feat: Update container tools

### DIFF
--- a/src/Dockerfile.android.dev
+++ b/src/Dockerfile.android.dev
@@ -40,8 +40,15 @@ RUN apt-get update && \
   clang-${LLVM_VERSION} \
   lldb-${LLVM_VERSION} \
   lld-${LLVM_VERSION} \
-  ccache \
-  vim
+  ccache 
+
+# Neovim requires manual retrieval of the latest version
+# as the apt package is quite old
+RUN wget https://github.com/neovim/neovim/releases/download/v0.8.0/nvim-linux64.deb \
+  -O /neovim.deb
+RUN apt install -y /neovim.deb 
+RUN rm /neovim.deb
+ENV EDITOR=nvim
 
 RUN groupadd -g ${USER_ID} ${USER_GROUP}
 RUN useradd -m -u ${USER_ID} -g ${GROUP_ID} ${USER_NAME} -s /bin/bash

--- a/src/scripts/devcontainer-check.sh
+++ b/src/scripts/devcontainer-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-required_packages="gh node vim git yarn"
+required_packages="gh node nvim git yarn"
 
 for exec in $required_packages;
 do


### PR DESCRIPTION
- Replace 'vim' with 'nvim'. This is done because nvim can be used as a
  server for vscode.
- Update `devcontainer-checks.sh` to check for 'nvim' instead of 'vim'.
